### PR TITLE
Add Klout.influencer_of and Klout.influenced_by. Also fix out of date specs and add API_KEY from command line for specs

### DIFF
--- a/lib/klout.rb
+++ b/lib/klout.rb
@@ -49,6 +49,11 @@ class Klout
       return request(request_uri)
     end
     
+    def influencer_of(usernames)
+      request_uri = "http://api.klout.com/1/soi/influencer_of.json?key=#{@@api_key}&users=#{usernames}"
+      return request(request_uri)
+    end
+    
     def request(request_uri)
       begin
         url = URI.parse(request_uri)

--- a/spec/klout_spec.rb
+++ b/spec/klout_spec.rb
@@ -82,6 +82,27 @@ describe "Klout" do
     
   end
   
+  context "profile request influencer of" do
+    before do
+      @profile_request ||= lambda {
+        Klout.influencer_of('markmcspadden')
+      }
+      @profile_result ||= @profile_request.call
+    end
+    
+    it "should have a profile" do
+      @profile_result.should be_instance_of(Hash)
+    end
+    
+    it "should have the required keys" do      
+      @profile_result['user'] = @profile_result["users"].first["influencees"].first
+      @profile_result.has_key?('user').should == true
+      @profile_result['user'].has_key?('twitter_screen_name').should == true
+      @profile_result['user'].has_key?('kscore').should == true
+    end
+    
+  end
+  
   
   
   


### PR DESCRIPTION
I wanted to add the "influence" apis to this gem. Tried running the specs and they were busted (most likely due to changes in the api) so I fixed them and added the option to insert your api key at the command line when you run the specs. Then went on to add the "influence" methods I wanted with working specs.

Let me know if you have any questions.

Mark
